### PR TITLE
Fix: table print style

### DIFF
--- a/R/hgwr.R
+++ b/R/hgwr.R
@@ -578,6 +578,8 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
     if (!inherits(x, "summary.hgwrm")) {
         stop("It's not a summary.hgwrm object.")
     }
+    args = list(...)
+    is_md = ifelse(!is.null(args$table.style), args$table.style == "md", FALSE)
 
     ### Call information
     cat("Hierarchical and geographically weighted regression model", fill = T)
@@ -597,6 +599,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
     }
     pv_gfe <- x$significance$beta$pv
     stars <- vapply(pv_gfe, pv2stars, rep(" ", n = length(pv_gfe)))
+    if (is_md) cat("\n")
     print.table.md(rbind(
         c("", "Estimated", "Sd. Err", "t.val", "Pr(>|t|)", ""),
         as.matrix(cbind(variable = gfe, x$significance$beta, stars = stars))
@@ -626,6 +629,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         c("", gamma_stats_name),
         cbind(lfe, gamma_stats)
     )
+    if (is_md) cat("\n")
     print.table.md(gamma_str, ...)
     cat("\n")
     if (!is.null(x$f_test)) {
@@ -636,6 +640,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
             c("", "F value", "Num. D.F.", "Den. D.F.", "Pr(>F)", ""),
             cbind(lfe, matrix2char(f_test_res), f_test_stars)
         )
+        if (is_md) cat("\n")
         print.table.md(f_test_str, ...)
         cat("\n")
     }
@@ -659,6 +664,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
             c("", hetero_stats_name),
             cbind(lfe, hetero_stats)
         )
+        if (is_md) cat("\n")
         print.table.md(hetero_str, ...)
         cat("\n")
     }
@@ -689,6 +695,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         cbind(random_dev_str, random_corr_str),
         random_residual_str
     )
+    if (is_md) cat("\n")
     print.table.md(random_str, ...)
     cat("\n", fill = T)
 
@@ -699,6 +706,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         names(x$diagnostic),
         matrix2char(unlist(x$diagnostic), decimal.fmt)
     )
+    if (is_md) cat("\n")
     print.table.md(diagnostic_chr, ...)
     cat("\n")
 
@@ -711,6 +719,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         c("Min", "1Q", "Median", "3Q", "Max"),
         matrix2char(residual_fivenum_mat, decimal.fmt)
     )
+    if (is_md) cat("\n")
     print.table.md(residual_fivenum_chr, ...)
     cat("\n")
     cat("Other Information", fill = T)

--- a/R/hgwr.R
+++ b/R/hgwr.R
@@ -506,34 +506,36 @@ print.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
     if (intercept$local) effects$local.fixed <- c("Intercept", effects$local.fixed)
     if (intercept$random) effects$random <- c("Intercept", effects$random)
     cat("Global Fixed Effects", fill = T)
-    cat("-------------------", fill = T)
+    cat("--------------------", fill = T)
     beta_str <- rbind(
         effects$global.fixed,
-        matrix2char(t(x$beta))
+        matrix2char(t(x$beta), decimal.fmt)
     )
     print.table.md(beta_str, ...)
     cat("\n")
     cat("Group-level Spatially Weighted Effects", fill = T)
-    cat("-------------------", fill = T)
+    cat("--------------------------------------", fill = T)
     cat("Bandwidth:", x$bw, "(nearest neighbours)", fill = T)
+    cat("\n")
+    cat("Coefficient estimates:", fill = T)
     gamma_fivenum <- t(apply(x$gamma, 2, fivenum))
     gamma_str <- rbind(
         c("Coefficient", "Min", "1st Quartile", "Median", "3rd Quartile", "Max"),
-        cbind(effects$local.fixed, matrix2char(gamma_fivenum))
+        cbind(effects$local.fixed, matrix2char(gamma_fivenum, decimal.fmt))
     )
     print.table.md(gamma_str, ...)
     cat("\n")
     cat("Sample-level Random Effects", fill = T)
-    cat("--------------", fill = T)
+    cat("---------------------------", fill = T)
     x <- summary.hgwrm(x)
     random_stddev <- x$random.stddev
     random_corr <- x$random.corr
-    random_corr_str <- matrix2char(random_corr)
+    random_corr_str <- matrix2char(random_corr, decimal.fmt)
     random_corr_str[!lower.tri(random_corr)] <- ""
     random_corr_str <- rbind("", random_corr_str)
     random_corr_str[1, 1] <- "Corr"
     random_dev_str <- cbind(
-        "", effects$random, matrix2char(matrix(random_stddev, ncol = 1))
+        "", effects$random, matrix2char(matrix(random_stddev, ncol = 1), decimal.fmt)
     )
     random_dev_str[1, 1] <- effects$group
     random_dev_str <- rbind(
@@ -599,7 +601,6 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
     }
     pv_gfe <- x$significance$beta$pv
     stars <- vapply(pv_gfe, pv2stars, rep(" ", n = length(pv_gfe)))
-    if (is_md) cat("\n")
     print.table.md(rbind(
         c("", "Estimated", "Sd. Err", "t.val", "Pr(>|t|)", ""),
         as.matrix(cbind(variable = gfe, x$significance$beta, stars = stars))
@@ -620,8 +621,8 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
     ) })) * 100
     rownames(s_gamma) <- lfe
     gamma_stats <- cbind(
-        gamma_mean <- matrix2char(as.vector(colMeans(x$gamma))),
-        gamma_se_mean <- matrix2char(as.vector(colMeans(x$gamma_se))),
+        gamma_mean <- matrix2char(as.vector(colMeans(x$gamma)), decimal.fmt),
+        gamma_se_mean <- matrix2char(as.vector(colMeans(x$gamma_se)), decimal.fmt),
         matrix2char(s_gamma, fmt = "%.1f%%")
     )
     gamma_stats_name <- c("Mean Est.", "Mean Sd.", colnames(s_gamma))
@@ -629,7 +630,6 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         c("", gamma_stats_name),
         cbind(lfe, gamma_stats)
     )
-    if (is_md) cat("\n")
     print.table.md(gamma_str, ...)
     cat("\n")
     if (!is.null(x$f_test)) {
@@ -638,9 +638,8 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         f_test_stars <-  vapply(f_test_res[,4], FUN = pv2stars, rep(" ", n = nrow(f_test_res)))
         f_test_str <- rbind(
             c("", "F value", "Num. D.F.", "Den. D.F.", "Pr(>F)", ""),
-            cbind(lfe, matrix2char(f_test_res), f_test_stars)
+            cbind(lfe, matrix2char(f_test_res, decimal.fmt), f_test_stars)
         )
-        if (is_md) cat("\n")
         print.table.md(f_test_str, ...)
         cat("\n")
     }
@@ -654,7 +653,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
             t.min = apply(h_gamma$t, 2, min),
             t.max = apply(h_gamma$t, 2, max),
             pv = pv_hetero
-        ))
+        ), decimal.fmt)
         hetero_stats <- cbind(
             hetero_stats,
             stars = vapply(pv_hetero, pv2stars, rep(" ", n = length(pv_hetero)))
@@ -664,14 +663,13 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
             c("", hetero_stats_name),
             cbind(lfe, hetero_stats)
         )
-        if (is_md) cat("\n")
         print.table.md(hetero_str, ...)
         cat("\n")
     }
     cat("SLR effects:", fill = T)
     random_stddev <- x$random.stddev
     random_corr <- x$random.corr
-    random_corr_str <- matrix2char(random_corr)
+    random_corr_str <- matrix2char(random_corr, decimal.fmt)
     random_corr_str[!lower.tri(random_corr)] <- ""
     random_corr_str <- rbind("", random_corr_str)
     random_corr_str[1, 1] <- "Corr"
@@ -680,7 +678,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         re <- c("Intercept", re)
     }
     random_dev_str <- cbind(
-        "", re, matrix2char(cbind(colMeans(x$mu), matrix(random_stddev, ncol = 1)))
+        "", re, matrix2char(cbind(colMeans(x$mu), matrix(random_stddev, ncol = 1)), decimal.fmt)
     )
     random_dev_str[1, 1] <- x$effects$group
     random_dev_str <- rbind(
@@ -695,7 +693,6 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         cbind(random_dev_str, random_corr_str),
         random_residual_str
     )
-    if (is_md) cat("\n")
     print.table.md(random_str, ...)
     cat("\n", fill = T)
 
@@ -706,7 +703,6 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         names(x$diagnostic),
         matrix2char(unlist(x$diagnostic), decimal.fmt)
     )
-    if (is_md) cat("\n")
     print.table.md(diagnostic_chr, ...)
     cat("\n")
 
@@ -719,7 +715,6 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
         c("Min", "1Q", "Median", "3Q", "Max"),
         matrix2char(residual_fivenum_mat, decimal.fmt)
     )
-    if (is_md) cat("\n")
     print.table.md(residual_fivenum_chr, ...)
     cat("\n")
     cat("Other Information", fill = T)

--- a/R/hgwr.R
+++ b/R/hgwr.R
@@ -636,7 +636,7 @@ print.summary.hgwrm <- function(x, decimal.fmt = "%.6f", ...) {
             c("", "F value", "Num. D.F.", "Den. D.F.", "Pr(>F)", ""),
             cbind(lfe, matrix2char(f_test_res), f_test_stars)
         )
-        print.table.md(f_test_str)
+        print.table.md(f_test_str, ...)
         cat("\n")
     }
     if (!is.null(x$significance$gamma$hetero)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,6 +39,19 @@ print.table.md <- function(
     table.style = c("plain", "md", "latex", "booktabs"),
     ...
 ) {
+    ### Special characters
+    if (!missing(table.style)) {
+        if (table.style == "md") {
+            x <- apply(x, c(1, 2), function(t) {
+                gsub("([\\|*])", "\\\\\\1", t)
+            })
+        } else if (table.style == "latex" || table.style == "booktabs") {
+            x <- apply(x, c(1, 2), function(t) {
+                gsub("([&%])", "\\\\\\1", t)
+            })
+        }
+    }
+    ### Process formats
     x.length <- apply(x, c(1, 2), nchar)
     x.length.max <- apply(x.length, 2, max)
     x.fmt <- sprintf("%%%ds", x.length.max)

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,6 +49,7 @@ print.table.md <- function(
             header.sep <- ifelse(missing(header.sep), "-", header.sep)
             row.begin <- ifelse(missing(row.begin), "|", row.begin)
             row.end <- ifelse(missing(row.end), "|", row.end)
+            table.before <- ifelse(missing(table.before), "", table.before)
         } else if (table.style == "latex") {
             col.sep <- ifelse(missing(col.sep), "&", col.sep)
             header.sep <- ifelse(missing(header.sep), "", header.sep)

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,44 +32,55 @@
 #' In this function, characters are right padded by spaces.
 #'
 #' @seealso [print.hgwrm()], [summary.hgwrm()].
-print.table.md <- function(x, col.sep = "", header.sep = "",
-                           row.begin = "", row.end = "",
-                           table.style = c("plain", "md", "latex"), ...) {
+print.table.md <- function(
+    x, col.sep = "", header.sep = "",
+    row.begin = "", row.end = "",
+    table.before = NA_character_, table.after = NA_character_,
+    table.style = c("plain", "md", "latex", "booktabs"),
+    ...
+) {
+    x.length <- apply(x, c(1, 2), nchar)
+    x.length.max <- apply(x.length, 2, max)
+    x.fmt <- sprintf("%%%ds", x.length.max)
     if (!missing(table.style)) {
         table.style <- match.arg(table.style)
         if (table.style == "md") {
-            col.sep <- "|"
-            header.sep <- "-"
-            row.begin <- "|"
-            row.end <- "|"
+            col.sep <- ifelse(missing(col.sep), "|", col.sep)
+            header.sep <- ifelse(missing(header.sep), "-", header.sep)
+            row.begin <- ifelse(missing(row.begin), "|", row.begin)
+            row.end <- ifelse(missing(row.end), "|", row.end)
         } else if (table.style == "latex") {
-            col.sep <- "&"
-            header.sep <- ""
-            row.begin <- ""
-            row.end <- "\\\\"
+            col.sep <- ifelse(missing(col.sep), "&", col.sep)
+            header.sep <- ifelse(missing(header.sep), "", header.sep)
+            row.begin <- ifelse(missing(row.begin), "", row.begin)
+            row.end <- ifelse(missing(row.end), "\\\\", row.end)
+            table.before <- ifelse(missing(table.before), sprintf("\\begin{tabular}{%s}", paste(rep("l", times = ncol(x)), collapse = "")), table.before)
+            table.after <- ifelse(missing(table.after), "\\end{tabular}", table.after)
         } else if (table.style == "plain") {
-            col.sep <- ""
-            header.sep <- ""
-            row.begin <- ""
-            row.end <- ""
+            col.sep <- ifelse(missing(col.sep), "", col.sep)
+            header.sep <- ifelse(missing(header.sep), "", header.sep)
+            row.begin <- ifelse(missing(row.begin), "", row.begin)
+            row.end <- ifelse(missing(row.end), "", row.end)
+        } else if (table.style == "booktabs") {
+            col.sep <- ifelse(missing(col.sep), "&", col.sep)
+            header.sep <- ifelse(missing(header.sep), "\\midrule", header.sep)
+            row.begin <- ifelse(missing(row.begin), "", row.begin)
+            row.end <- ifelse(missing(row.end), "\\\\", row.end)
+            table.before <- ifelse(missing(table.before), sprintf("\\begin{tabular}{%s}\n\\toprule", paste(rep("l", times = ncol(x)), collapse = "")), table.before)
+            table.after <- ifelse(missing(table.after), "\\bottomrule\n\\end{tabular}", table.after)
         } else {
            stop("Unknown table.style.")
         }
     }
-    if (nchar(header.sep) > 1) {
-       stop("Currently only 1 character header.sep is supported.")
-    }
     ### Print table
-    x.length <- apply(x, c(1, 2), nchar)
-    x.length.max <- apply(x.length, 2, max)
-    x.fmt <- sprintf("%%%ds", x.length.max)
+    if (!is.na(table.before)) cat(table.before, fill = T)
     for(c in 1:ncol(x)) {
         if(x.length.max[c] > 0)
             cat(ifelse(c == 1, row.begin, col.sep),
                 sprintf(x.fmt[c], x[1, c]), "")
     }
     cat(paste0(row.end, "\n"))
-    if (nchar(header.sep) > 0) {
+    if (nchar(header.sep) == 1) {
         for(c in 1:ncol(x)) {
             if(x.length.max[c] > 0) {
                 header.sep.full <- paste(rep("-", x.length.max[c]),
@@ -79,6 +90,8 @@ print.table.md <- function(x, col.sep = "", header.sep = "",
             }
         }
         cat(paste0(row.end, "\n"))
+    } else if (nchar(header.sep) > 1) {
+        cat(paste0(header.sep, "\n"))
     }
     for (r in 2:nrow(x)) {
         for (c in 1:ncol(x)) {
@@ -88,6 +101,7 @@ print.table.md <- function(x, col.sep = "", header.sep = "",
         }
         cat(paste0(row.end, "\n"))
     }
+    if (!is.na(table.after)) cat(table.after, fill = T)
 }
 
 #' Convert a numeric matrix to character matrix according to a format string.


### PR DESCRIPTION
Markdown style:

- Add blank lines before tables
- Add `\` before characters `|*`

LaTeX style:

- Add `\` before characters `&%`
- Add environments around tables
- A new style "booktabs"